### PR TITLE
ci: fix artifact conflict (unique SBOM per matrix node)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,10 @@ jobs:
       - run: npm run smoke || true
       - run: npm test -- --reporter dot || true
       - run: npm audit --omit=dev || true
-      - run: npx @cyclonedx/cyclonedx-npm --output-file sbom/bom.json
+
+      - run: mkdir -p sbom
+      - run: npx @cyclonedx/cyclonedx-npm --output-file sbom/bom-${{ matrix.node }}.json
       - uses: actions/upload-artifact@v4
         with:
-          name: sbom
-          path: sbom/bom.json
+          name: sbom-${{ matrix.node }}
+          path: sbom/bom-${{ matrix.node }}.json


### PR DESCRIPTION
## Summary
- ensure SBOM files and artifacts are generated with unique names per Node.js matrix entry
- create the sbom directory before generating the CycloneDX report to avoid missing path errors

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca6371a6e48332ad851e7a44379930