### PR TITLE
feat: bootstrap CLI i18n layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint CLI for i18n strings
+        run: npm run lint:cli-i18n
+
+      - name: Verify CLI help output
+        run: |
+          node cli.mjs --help --lang en | tee cli-help.txt
+          grep "Parse a VNL sentence and produce a Ukrainian plan." cli-help.txt
+
+      - name: Run smoke tests
+        run: npm run smoke
+
+      - name: Upload canonical artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: canonical-dist
+          path: dist/canonical
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@
 - Людині — рідна мова і прозорі смисли.
 - Машині — стабільні англомовні контракти, інструменти, CI.
 
+## Language & i18n policy
+- The MOVA CLI speaks canonical English by default for all user-facing hints.
+- Select a locale with `--lang <code>` or the `MOVA_LANG` environment variable (`--lang` wins when both are set).
+- Only `en` is currently available; unsupported language codes emit a warning and fall back to English.
+- Schemas, identifiers, keys, and parameter names stay in English. Additional locales are introduced on demand when high-quality translations are ready.
+
 ## Стандарти
 - JSON Schema 2020-12 — структурна валідація.
 - OpenAPI 3.1 — опис HTTP інтерфейсів (у CI).

--- a/cli.mjs
+++ b/cli.mjs
@@ -1,51 +1,125 @@
 import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
+import { DEFAULT_LANGUAGE, isSupportedLanguage, setLanguage, t } from './src/i18n/i18n.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const [,, command, ...args] = process.argv;
+const rawArgs = process.argv.slice(2);
+const filteredArgs = [];
+let languageFromFlag;
+let langFlagProvided = false;
+
+for (let index = 0; index < rawArgs.length; index += 1) {
+    const value = rawArgs[index];
+
+    if (value === '--lang') {
+        langFlagProvided = true;
+        const nextValue = rawArgs[index + 1];
+        if (typeof nextValue === 'string' && !nextValue.startsWith('--')) {
+            languageFromFlag = nextValue;
+            index += 1;
+        } else {
+            console.warn(t('warnings.missingLanguageArgument'));
+        }
+        continue;
+    }
+
+    if (value.startsWith('--lang=')) {
+        langFlagProvided = true;
+        const potential = value.slice('--lang='.length);
+        if (potential) {
+            languageFromFlag = potential;
+        } else {
+            console.warn(t('warnings.missingLanguageArgument'));
+        }
+        continue;
+    }
+
+    filteredArgs.push(value);
+}
+
+const environmentLanguage = process.env.MOVA_LANG;
+if (langFlagProvided && environmentLanguage) {
+    console.warn(t('cli.ignoredEnvLanguage'));
+}
+
+let requestedLanguage = langFlagProvided ? languageFromFlag : environmentLanguage;
+if (typeof requestedLanguage === 'string') {
+    requestedLanguage = requestedLanguage.trim().toLowerCase();
+}
+
+if (requestedLanguage && !isSupportedLanguage(requestedLanguage)) {
+    console.warn(t('warnings.unsupportedLanguage', { requested: requestedLanguage }));
+    requestedLanguage = DEFAULT_LANGUAGE;
+}
+
+setLanguage(requestedLanguage ?? DEFAULT_LANGUAGE);
+
+const [command, ...args] = filteredArgs;
 
 const scripts = {
     'parse': {
         path: 'scripts/language/parse_vnl.mjs',
-        description: 'Парсить речення VNL і генерує український план.\n  Приклад: parse "send message to general"'
+        descriptionKey: 'commands.parse.description',
+        exampleKey: 'commands.parse.example'
     },
     'run': {
         path: 'scripts/runtime/run_plan.mjs',
-        description: 'Виконує канонічний (англійський) план.\n  Приклад: run canonical/plan_min.json'
+        descriptionKey: 'commands.run.description',
+        exampleKey: 'commands.run.example'
     },
     'build': {
         npm: 'build:ua',
-        description: 'Збирає та валідує українські шаблони, створюючи канонічні файли.'
+        descriptionKey: 'commands.build.description',
+        exampleKey: 'commands.build.example'
     },
     'translate:reverse': {
         npm: 'translate:en-ua',
-        description: 'Перекладає всі канонічні файли з /canonical на українську в /templates/ua/from-en.'
+        descriptionKey: 'commands.translateReverse.description',
+        exampleKey: 'commands.translateReverse.example'
     },
     'fingerprint': {
         npm: 'build:fingerprint',
-        description: 'Генерує "відбиток" (хеші) для всіх схем у build/schema_fingerprint.json.'
+        descriptionKey: 'commands.fingerprint.description',
+        exampleKey: 'commands.fingerprint.example'
     },
     'help': {
-        description: 'Показує цю довідку.'
+        descriptionKey: 'commands.help.description'
     }
 };
 
+const longestCommandLength = Object.keys(scripts)
+    .reduce((max, name) => Math.max(max, name.length), 0);
+
 function printHelp() {
-    console.log('--- Інтерфейс командного рядка MOVA ---');
-    console.log('\nВикористання: npm run cli -- <команда> [аргументи]\n');
-    console.log('Доступні команди:\n');
-    for (const cmd in scripts) {
-        // Pad the command name for alignment
-        const paddedCmd = cmd.padEnd(20, ' ');
-        console.log(`  ${paddedCmd} ${scripts[cmd].description}`);
+    console.log(t('cli.header'));
+    console.log('');
+    console.log(t('cli.usage'));
+    console.log('');
+    console.log(t('cli.availableCommands'));
+    console.log('');
+
+    for (const cmd of Object.keys(scripts)) {
+        const config = scripts[cmd];
+        const description = t(config.descriptionKey);
+        const paddedCmd = cmd.padEnd(longestCommandLength + 2, ' ');
+        console.log(t('cli.commandItem', { command: paddedCmd, description }));
+
+        if (config.exampleKey) {
+            const example = t(config.exampleKey);
+            if (example !== config.exampleKey) {
+                console.log(t('cli.example', { example }));
+            }
+        }
     }
-    console.log('\n----------------------------------------');
+
+    console.log('');
+    console.log(t('cli.footer'));
 }
 
-if (!command || command === 'help') {
+if (!command || command === 'help' || command === '--help' || command === '-h') {
     printHelp();
     process.exit(0);
 }
@@ -53,55 +127,52 @@ if (!command || command === 'help') {
 const scriptConfig = scripts[command];
 
 if (!scriptConfig) {
-    console.error(`❌ Невідома команда: "${command}"`);
+    console.error('❌ ' + t('errors.unknownCommand', { command }));
     printHelp();
     process.exit(1);
 }
 
-// Function to run a node script
 function runNodeScript(scriptPath, scriptArgs) {
     const fullPath = resolve(__dirname, scriptPath);
-    // For VNL parser, we need to join args back into a sentence
     const finalArgs = scriptPath.includes('parse_vnl') ? [scriptArgs.join(' ')] : scriptArgs;
 
     const child = spawn('node', [fullPath, ...finalArgs], { stdio: 'inherit' });
 
     child.on('close', (code) => {
         if (code !== 0) {
-            console.error(`\n💥 Скрипт завершився з кодом помилки: ${code}`);
+            console.error('');
+            console.error('💥 ' + t('errors.scriptFailed', { code }));
         }
         process.exit(code);
     });
 
     child.on('error', (err) => {
-        console.error(`💥 Помилка запуску скрипта ${scriptPath}:`, err);
+        console.error('💥 ' + t('errors.scriptSpawn', { script: scriptPath }));
+        console.error(err);
         process.exit(1);
     });
 }
 
-// Function to run an npm script
 function runNpmScript(scriptName) {
-    // 'shell: true' is important for cross-platform compatibility, especially on Windows
     const child = spawn('npm', ['run', scriptName], { stdio: 'inherit', shell: true });
 
     child.on('close', (code) => {
         if (code !== 0) {
-            console.error(`\n💥 npm-скрипт завершився з кодом помилки: ${code}`);
+            console.error('');
+            console.error('💥 ' + t('errors.npmScriptFailed', { code }));
         }
         process.exit(code);
     });
 
     child.on('error', (err) => {
-        console.error(`💥 Помилка запуску npm-скрипта ${scriptName}:`, err);
+        console.error('💥 ' + t('errors.npmScriptSpawn', { script: scriptName }));
+        console.error(err);
         process.exit(1);
     });
 }
 
-
 if (scriptConfig.path) {
-    // It's a direct node script
     runNodeScript(scriptConfig.path, args);
 } else if (scriptConfig.npm) {
-    // It's an npm script
     runNpmScript(scriptConfig.npm);
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "smoke": "node scripts/run/smoke.mjs templates/canonical",
     "build:all": "npm run forms:lint && npm run forms:build:dev && npm run validate:canonical && npm run smoke",
     "release:check": "npm run forms:lint && npm run forms:build:prod && npm run validate:canonical && npm run smoke",
+    "lint:cli-i18n": "node scripts/lint/check_cli_i18n.mjs",
     "start:ui": "node server.js",
     "run": "node scripts/runtime/run_plan.mjs",
     "cli": "node cli.mjs"

--- a/scripts/lint/check_cli_i18n.mjs
+++ b/scripts/lint/check_cli_i18n.mjs
@@ -1,0 +1,43 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../..');
+const cliFilePath = path.join(projectRoot, 'cli.mjs');
+
+const source = await readFile(cliFilePath, 'utf8');
+
+const literalPattern = /(['"`])((?:\\.|(?!\1)[\s\S])*)\1/g;
+const violations = [];
+let match;
+
+while ((match = literalPattern.exec(source)) !== null) {
+    const literal = match[2];
+    const trimmed = literal.trim();
+
+    if (!trimmed) {
+        continue;
+    }
+
+    if (!/[A-Za-z]/.test(trimmed)) {
+        continue;
+    }
+
+    if (!/\s/.test(trimmed)) {
+        continue;
+    }
+
+    const preceding = source.slice(0, match.index);
+    const line = preceding.split('\n').length;
+    violations.push({ literal, line });
+}
+
+if (violations.length > 0) {
+    console.error('Found hard-coded CLI strings. Move user-facing text to src/i18n/locales.');
+    for (const violation of violations) {
+        console.error(`  line ${violation.line}: "${violation.literal}"`);
+    }
+    process.exit(1);
+}

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -1,0 +1,116 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+export const SUPPORTED_LANGUAGES = ['en'];
+export const DEFAULT_LANGUAGE = 'en';
+
+const resourcesCache = new Map();
+let activeLanguage = DEFAULT_LANGUAGE;
+const supportedLanguageSet = new Set(SUPPORTED_LANGUAGES);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function loadLocaleResources(language) {
+    if (resourcesCache.has(language)) {
+        return resourcesCache.get(language);
+    }
+
+    try {
+        const localeFilePath = path.join(__dirname, 'locales', language, 'app.json');
+        const fileContent = readFileSync(localeFilePath, 'utf8');
+        const parsed = JSON.parse(fileContent);
+        resourcesCache.set(language, parsed);
+        return parsed;
+    } catch (error) {
+        if (language !== DEFAULT_LANGUAGE) {
+            const fallback = loadLocaleResources(DEFAULT_LANGUAGE);
+            resourcesCache.set(language, fallback);
+            return fallback;
+        }
+        throw error;
+    }
+}
+
+function getTranslation(tree, key) {
+    const segments = key.split('.');
+    let current = tree;
+
+    for (const segment of segments) {
+        if (typeof current !== 'object' || current === null) {
+            return undefined;
+        }
+
+        if (!Object.prototype.hasOwnProperty.call(current, segment)) {
+            return undefined;
+        }
+
+        current = current[segment];
+    }
+
+    return typeof current === 'string' ? current : undefined;
+}
+
+function formatMessage(template, params) {
+    if (!params) {
+        return template;
+    }
+
+    return template.replace(/\{\{(.*?)\}\}/g, (_, rawKey) => {
+        const trimmedKey = rawKey.trim();
+        if (Object.prototype.hasOwnProperty.call(params, trimmedKey)) {
+            const value = params[trimmedKey];
+            return value === undefined || value === null ? '' : String(value);
+        }
+        return '';
+    });
+}
+
+export function getSupportedLanguages() {
+    return [...SUPPORTED_LANGUAGES];
+}
+
+export function isSupportedLanguage(language) {
+    if (typeof language !== 'string') {
+        return false;
+    }
+
+    return supportedLanguageSet.has(language);
+}
+
+export function setLanguage(language) {
+    const normalized = typeof language === 'string' ? language.trim().toLowerCase() : '';
+    if (isSupportedLanguage(normalized)) {
+        activeLanguage = normalized;
+    } else {
+        activeLanguage = DEFAULT_LANGUAGE;
+    }
+
+    loadLocaleResources(activeLanguage);
+    return activeLanguage;
+}
+
+export function getCurrentLanguage() {
+    return activeLanguage;
+}
+
+export function t(key, params) {
+    const activeResources = loadLocaleResources(activeLanguage);
+    const fallbackResources = loadLocaleResources(DEFAULT_LANGUAGE);
+
+    let message = getTranslation(activeResources, key);
+
+    if (message === undefined) {
+        message = getTranslation(fallbackResources, key);
+    }
+
+    if (message === undefined) {
+        return key;
+    }
+
+    return formatMessage(message, params);
+}
+
+// Warm up the default locale so the cache always has English resources.
+loadLocaleResources(DEFAULT_LANGUAGE);

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+type TranslationValue = string | TranslationTree;
+interface TranslationTree {
+    [key: string]: TranslationValue;
+}
+export type TranslationParams = Record<string, string | number>;
+
+export const SUPPORTED_LANGUAGES = ['en'] as const;
+export type SupportedLanguage = typeof SUPPORTED_LANGUAGES[number];
+
+export const DEFAULT_LANGUAGE: SupportedLanguage = 'en';
+
+const resourcesCache = new Map<string, TranslationTree>();
+let activeLanguage: SupportedLanguage = DEFAULT_LANGUAGE;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function loadLocaleResources(language: string): TranslationTree {
+    if (resourcesCache.has(language)) {
+        return resourcesCache.get(language)!;
+    }
+
+    try {
+        const localeFilePath = path.join(__dirname, 'locales', language, 'app.json');
+        const fileContent = readFileSync(localeFilePath, 'utf8');
+        const parsed = JSON.parse(fileContent) as TranslationTree;
+        resourcesCache.set(language, parsed);
+        return parsed;
+    } catch (error) {
+        if (language !== DEFAULT_LANGUAGE) {
+            const fallback = loadLocaleResources(DEFAULT_LANGUAGE);
+            resourcesCache.set(language, fallback);
+            return fallback;
+        }
+        throw error;
+    }
+}
+
+function getTranslation(tree: TranslationTree, key: string): string | undefined {
+    const segments = key.split('.');
+    let current: TranslationValue = tree;
+
+    for (const segment of segments) {
+        if (typeof current !== 'object' || current === null) {
+            return undefined;
+        }
+
+        if (!(segment in current)) {
+            return undefined;
+        }
+
+        current = (current as TranslationTree)[segment];
+    }
+
+    return typeof current === 'string' ? current : undefined;
+}
+
+function formatMessage(template: string, params?: TranslationParams): string {
+    if (!params) {
+        return template;
+    }
+
+    return template.replace(/\{\{(.*?)\}\}/g, (_, rawKey: string) => {
+        const trimmedKey = rawKey.trim();
+        if (Object.prototype.hasOwnProperty.call(params, trimmedKey)) {
+            const value = params[trimmedKey];
+            return value === undefined || value === null ? '' : String(value);
+        }
+        return '';
+    });
+}
+
+export function getSupportedLanguages(): SupportedLanguage[] {
+    return [...SUPPORTED_LANGUAGES];
+}
+
+export function isSupportedLanguage(language: string): language is SupportedLanguage {
+    return SUPPORTED_LANGUAGES.includes(language as SupportedLanguage);
+}
+
+export function setLanguage(language: string | undefined | null): SupportedLanguage {
+    const normalized = typeof language === 'string' ? language.trim().toLowerCase() : '';
+    if (isSupportedLanguage(normalized)) {
+        activeLanguage = normalized;
+    } else {
+        activeLanguage = DEFAULT_LANGUAGE;
+    }
+
+    loadLocaleResources(activeLanguage);
+    return activeLanguage;
+}
+
+export function getCurrentLanguage(): SupportedLanguage {
+    return activeLanguage;
+}
+
+export function t(key: string, params?: TranslationParams): string {
+    const activeResources = loadLocaleResources(activeLanguage);
+    const fallbackResources = loadLocaleResources(DEFAULT_LANGUAGE);
+
+    let message = getTranslation(activeResources, key);
+
+    if (message === undefined) {
+        message = getTranslation(fallbackResources, key);
+    }
+
+    if (message === undefined) {
+        return key;
+    }
+
+    return formatMessage(message, params);
+}
+
+// Warm up the default locale so the cache always has English resources.
+loadLocaleResources(DEFAULT_LANGUAGE);

--- a/src/i18n/locales/en/app.json
+++ b/src/i18n/locales/en/app.json
@@ -1,0 +1,47 @@
+{
+  "cli": {
+    "header": "--- MOVA Command Line Interface ---",
+    "usage": "Usage: npm run cli -- <command> [arguments]",
+    "availableCommands": "Available commands:",
+    "commandItem": "  {{command}} {{description}}",
+    "example": "    {{example}}",
+    "footer": "----------------------------------------",
+    "ignoredEnvLanguage": "Environment variable MOVA_LANG is ignored because --lang was provided."
+  },
+  "warnings": {
+    "unsupportedLanguage": "Language \"{{requested}}\" is not supported. Falling back to English.",
+    "missingLanguageArgument": "The --lang option requires a language code. Falling back to English."
+  },
+  "errors": {
+    "unknownCommand": "Unknown command \"{{command}}\". Run \"help\" to see the full list.",
+    "scriptFailed": "Script exited with error code {{code}}.",
+    "scriptSpawn": "Unable to launch script {{script}}.",
+    "npmScriptFailed": "npm script exited with error code {{code}}.",
+    "npmScriptSpawn": "Unable to launch npm script {{script}}."
+  },
+  "commands": {
+    "parse": {
+      "description": "Parse a VNL sentence and produce a Ukrainian plan.",
+      "example": "Example: parse \"send message to general\""
+    },
+    "run": {
+      "description": "Execute a canonical (English) plan file.",
+      "example": "Example: run canonical/plan_min.json"
+    },
+    "build": {
+      "description": "Build and validate Ukrainian templates to produce canonical files.",
+      "example": "Example: build"
+    },
+    "translateReverse": {
+      "description": "Translate canonical files from /canonical to Ukrainian in /templates/ua/from-en.",
+      "example": "Example: translate:reverse"
+    },
+    "fingerprint": {
+      "description": "Generate fingerprints for all schemas in build/schema_fingerprint.json.",
+      "example": "Example: fingerprint"
+    },
+    "help": {
+      "description": "Display this help message."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an i18n helper with English resources and fallback behaviour
- switch the CLI to English defaults with a --lang flag, MOVA_LANG support, and translated prompts
- document the language policy, enforce string extraction, and extend CI to cover the CLI help output

## Testing
- npm run lint:cli-i18n
- node cli.mjs --help --lang en
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_e_68cbd2ed92a48332b3be213199add012